### PR TITLE
Supported implicit combined image sampler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "shaderc"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shaderc-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "shaderc-sys"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "spirq"
 version = "0.4.3"
 dependencies = [
@@ -323,6 +341,7 @@ dependencies = [
  "nohash-hasher 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shaderc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spirv_headers 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -492,6 +511,8 @@ dependencies = [
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+"checksum shaderc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ed344938df2d7fa3cc6bfb4af0b578f00f9b389d5fe7be0250fa657c442a8281"
+"checksum shaderc-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30075c712b08798cb2b5e54e4434970a4a3a3a3e838b0642590c74605d3cc528"
 "checksum spirv_headers 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3f1418983d16481227ffa3ab3cf44ef92eebc9a76c092fbcd4c51a64ff032622"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ bytes = "0.5.6"
 byteorder = "1.3.4"
 glsl-to-spirv-macros = "0.1.1"
 glsl-to-spirv-macros-impl = "0.1.0"
+shaderc = { version="0.6.2", features=["build-from-source"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,6 @@ impl Error {
     pub const DESC_BIND_COLLISION: Self = Self::CorruptedSpirv("descriptor binding cannot be shared");
     pub const UNKNOWN_NBIND: Self = Self::CorruptedSpirv("binding count cannot be determined");
     pub const MULTI_PUSH_CONST: Self = Self::CorruptedSpirv("an entry point cannot have multiple push constant blocks");
-    pub const NONSCALAR_SPEC_CONST: Self = Self::CorruptedSpirv("specialization constant must be a scalar");
     pub const SPEC_ID_COLLISION: Self = Self::CorruptedSpirv("specialization id can only be assigned once");
 
     pub const UNSUPPORTED_TY: Self = Self::UnsupportedSpirv("unsupported type");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl InterfaceLocation {
     pub fn new(loc: u32, comp: u32) -> Self { InterfaceLocation(loc, comp) }
 
     pub fn loc(&self) -> u32 { self.0 }
-    pub fn bind(&self) -> u32 { self.1 }
+    pub fn comp(&self) -> u32 { self.1 }
     pub fn into_inner(self) -> (u32, u32) { (self.0, self.1) }
 }
 impl fmt::Display for InterfaceLocation {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,16 +286,23 @@ pub enum AccessType {
     /// The variable has been read from and written to.
     ReadWrite = 3,
 }
+impl std::ops::Add<AccessType> for AccessType {
+    type Output = AccessType;
+    fn add(self, rhs: AccessType) -> AccessType {
+        use num_traits::FromPrimitive;
+        AccessType::from_u32((self as u32) + (rhs as u32)).unwrap()
+    }
+}
 
 /// A set of information used to describe variable typing and routing.
 #[derive(Default, Clone)]
 pub struct Manifest {
-    pub(crate) push_const_ty: Option<Type>,
-    pub(crate) input_map: IntMap<InterfaceLocationCode, Type>,
-    pub(crate) output_map: IntMap<InterfaceLocationCode, Type>,
-    pub(crate) desc_map: IntMap<DescriptorBindingCode, DescriptorType>,
-    pub(crate) var_name_map: HashMap<String, ResourceLocator>,
-    pub(crate) desc_access_map: IntMap<DescriptorBindingCode, AccessType>
+    push_const_ty: Option<Type>,
+    input_map: IntMap<InterfaceLocationCode, Type>,
+    output_map: IntMap<InterfaceLocationCode, Type>,
+    desc_map: IntMap<DescriptorBindingCode, DescriptorType>,
+    var_name_map: HashMap<String, ResourceLocator>,
+    desc_access_map: IntMap<DescriptorBindingCode, AccessType>
 }
 impl Manifest {
     fn merge_ivars(
@@ -568,15 +575,102 @@ impl Manifest {
                 }
             })
     }
+
+    pub(crate) fn insert_rsc_name(&mut self, name: &str, rsc_locator: ResourceLocator) -> Result<()> {
+        if self.var_name_map.insert(name.to_owned(), rsc_locator).is_some() {
+            Err(Error::NAME_COLLISION)
+        } else { Ok(()) }
+    }
+    pub(crate) fn insert_input(&mut self, location: InterfaceLocation, ivar_ty: Type) -> Result<()> {
+        // Input variables can share locations (aliasing).
+        self.input_map.insert(location.into(), ivar_ty);
+        Ok(())
+    }
+    pub(crate) fn insert_output(&mut self, location: InterfaceLocation, ivar_ty: Type) -> Result<()> {
+        // Ouput variables can share locations (aliasing).
+        self.output_map.insert(location.into(), ivar_ty);
+        Ok(())
+    }
+    pub(crate) fn insert_desc(
+        &mut self,
+        desc_bind: DescriptorBinding,
+        desc_ty: DescriptorType,
+        access: AccessType,
+    ) -> Result<()> {
+        use std::collections::hash_map::Entry::{Vacant, Occupied};
+        fn combine_img_sampler(
+            nbind_samp: u32,
+            nbind_img: u32,
+            img_ty: &Type,
+            access_samp: AccessType,
+            access_img: AccessType,
+        ) -> Vec<(DescriptorType, AccessType)> {
+            use std::cmp::Ordering;
+            match nbind_samp.cmp(&nbind_img) {
+                Ordering::Equal => vec![
+                    (DescriptorType::SampledImage(nbind_img, img_ty.clone()), access_samp + access_img)
+                ],
+                Ordering::Less => vec![
+                    (DescriptorType::SampledImage(nbind_samp, img_ty.clone()), access_samp + access_img),
+                    (DescriptorType::Image(nbind_img - nbind_samp, img_ty.clone()), access_img),
+                ],
+                Ordering::Greater => vec![
+                    (DescriptorType::SampledImage(nbind_img, img_ty.clone()), access_samp + access_img),
+                    (DescriptorType::Sampler(nbind_samp - nbind_img), access_samp),
+                ],
+            }
+        }
+        // Allow override of resource access...?
+        self.desc_access_map.insert(desc_bind.into(), access);
+        // Descriptors cannot share bindings, but separate image and
+        // sampler can be fused implicitly into a
+        // `CombinedImageSampler` by sharing bindings.
+        let replaces = match self.desc_map.entry(desc_bind.into()) {
+            Vacant(entry) => {
+                entry.insert(desc_ty);
+                Vec::new()
+            },
+            Occupied(entry) => {
+                let replaces = match (entry.get(), &desc_ty) {
+                    (DescriptorType::Sampler(nbind_samp), DescriptorType::Image(nbind_img, img_ty)) => {
+                        let access_samp = self.desc_access_map[&desc_bind.into()];
+                        combine_img_sampler(*nbind_samp, *nbind_img, &img_ty, access_samp, access)
+                    },
+                    (DescriptorType::Image(nbind_img, img_ty), DescriptorType::Sampler(nbind_samp)) => {
+                        let access_img = self.desc_access_map[&desc_bind.into()];
+                        combine_img_sampler(*nbind_samp, *nbind_img, &img_ty, access, access_img)
+                    },
+                    _ => return Err(Error::DESC_BIND_COLLISION),
+                };
+                entry.remove();
+                replaces
+            },
+        };
+        // Insert replace items back to the manifest.
+        let mut replace_bind = desc_bind.bind();
+        // `replaces`'s base binding MUST BE monotonically increamental.
+        for (desc_ty, access) in replaces {
+            let nbind = desc_ty.nbind();
+            self.insert_desc(DescriptorBinding(desc_bind.set(), replace_bind), desc_ty, access)?;
+            replace_bind += nbind;
+        }
+        Ok(())
+    }
+    pub(crate) fn insert_push_const(&mut self, push_const_ty: Type) -> Result<()> {
+        if self.push_const_ty.is_none() {
+            self.push_const_ty = Some(push_const_ty);
+            Ok(())
+        } else { Err(Error::MULTI_PUSH_CONST) }
+    }
 }
 
 /// Entry point specialization descriptions.
 #[derive(Default, Clone)]
 pub struct Specialization {
     /// Mapping from specialization constant names to their IDs.
-    pub(crate) spec_const_name_map: HashMap<String, SpecId>,
+    spec_const_name_map: HashMap<String, SpecId>,
     /// Mapping from specialization IDs to specialization constant types.
-    pub(crate) spec_const_map: IntMap<SpecId, Type>,
+    spec_const_map: IntMap<SpecId, Type>,
 }
 impl Specialization {
     pub fn resolve_spec_const<S: AsRef<Sym>>(&self, sym: S) -> Option<SpecConstantResolution> {
@@ -609,6 +703,17 @@ impl Specialization {
                     ty
                 }
             })
+    }
+
+    pub fn insert_spec_const(&mut self, spec_id: SpecId, ty: Type) -> Result<()> {
+        if self.spec_const_map.insert(spec_id, ty).is_some() {
+            Err(Error::SPEC_ID_COLLISION)
+        } else { Ok(()) }
+    }
+    pub fn insert_spec_const_name(&mut self, name: &str, spec_id: SpecId) -> Result<()>{
+        if self.spec_const_name_map.insert(name.to_owned(), spec_id).is_some() {
+            Err(Error::NAME_COLLISION)
+        } else { Ok(()) }
     }
 }
 


### PR DESCRIPTION
See Chapter 14.5.2. in Vulkan specification 1.5.145:

> SPIR-V variables decorated with a descriptor set and binding that identify a combined image sampler descriptor **can** have a type of `OpTypeImage`, `OpTypeSampler` (`Sampled`=1), or `OpTypeSampledImage`.