### PR TITLE
Add struct definition name to type::StructType

### DIFF
--- a/src/reflect.rs
+++ b/src/reflect.rs
@@ -278,6 +278,7 @@ impl<'a> ReflectIntermediate<'a> {
             OP_TYPE_STRUCT => {
                 let op = OpTypeStruct::try_from(instr)?;
                 let mut struct_ty = StructType::default();
+                struct_ty.name = self.get_name(op.ty_id, None).map(|n| n.to_string());
                 for (i, &member_ty_id) in op.member_ty_ids.iter().enumerate() {
                     let i = i as u32;
                     let mut member_ty = self.ty_map.get(&member_ty_id)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -189,6 +189,37 @@ fn test_desc_tys() {
         } else {
             assert_eq!(entry.get_desc_access(desc.desc_bind).unwrap(), AccessType::ReadOnly);
         }
+
+        if desc.desc_bind == DescriptorBinding(0, 0) {
+            let members = desc
+                .member_var_res
+                .expect("did not resolve struct def as member");
+            if let crate::Type::Struct(s) = members.ty {
+                assert_eq!(s.name().expect("name was not populated for struct"), "A");
+            } else {
+                assert!(
+                    false,
+                    "expected a uniform struct definition, got {:?}",
+                    members.ty
+                );
+            }
+        } else if desc.desc_bind == DescriptorBinding(0, 3) {
+            let members = desc
+                .member_var_res
+                .expect("did not resolve struct def as member");
+            if let crate::Type::Struct(s) = members.ty {
+                assert_eq!(
+                    s.name().expect("name was not populated for buffer struct"),
+                    "F"
+                );
+            } else {
+                assert!(
+                    false,
+                    "expected a buffer struct definition, got {:?}",
+                    members.ty
+                );
+            }
+        }
     }
 }
 #[test]

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -309,11 +309,15 @@ pub struct StructMember {
 }
 #[derive(PartialEq, Eq, Default, Clone)]
 pub struct StructType {
+    pub(crate) name: Option<String>,
     members: Vec<StructMember>, // Offset and type.
     // BTreeMap to keep the order for hashing.
     name_map: BTreeMap<String, usize>,
 }
 impl StructType {
+    pub fn name(&self) -> Option<&String> {
+        self.name.as_ref()
+    }
     pub fn nbyte(&self) -> usize {
         self.members.last()
             .map(|last| last.offset + last.ty.nbyte().unwrap_or(0))
@@ -376,6 +380,9 @@ impl Hash for StructType {
 }
 impl fmt::Debug for StructType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(name) = &self.name {
+            f.write_str(name.as_str())?;
+        }
         f.write_str("{ ")?;
         for (i, member) in self.members.iter().enumerate() {
             if i != 0 { f.write_str(", ")?; }


### PR DESCRIPTION
The field itself is an `Option<String>` which should fail gracefully if
the name is not contained in the name map. Accessing the struct name
can be helpful in many cases, particularly when using `spirq` for code
generation.

The `test_desc_tys` test has been updated to check the two structures there.
I didn't see any other relevant test(s), but let me know if that's not true.

No breaking changes or modifications to existing APIs, so shipping as `0.4.8` should be easy.