### PR TITLE
Properly distinguish input/ouput when resolving symbol by name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spirq"
-version = "0.4.8"
+version = "0.4.9"
 authors = ["PENGUINLIONG <admin@penguinliong.moe>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
NOTE: I have included the version bump so you don't have to make another commit just for it.
Happy to remove it if that makes it cleaner or whatever.

Currently, when resolving a `Sym` by name, as long as a symbol with that
name exists it will be returned. This is incorrect as providing a symbol
name for an output in `Manifest::resolve_input(...)` will return an
output (and vice versa).

The issue ultimately comes down to the `Manifest::resolve_ivar(...)`
function not having input/output information [1]. While the input/output
map is given, when resolution uses the `var_name_map` instead, the
context is lost.

To solve this, I added a `ResolveKind` enum which is given to
`resolve_ivar(...)` which it can then use to discriminate based on the
input/output status of the symbol.

No external facing API was changed, so should be a simple update.
Essentially a "bug fix" so point-release is reasonable

[1] https://github.com/PENGUINLIONG/spirq-rs/blob/ca8ec0892f9b9608d369f9e3b331a5155caec528/src/lib.rs#L490