### PR TITLE
Fixes needed by screen-13

### DIFF
--- a/spirq-core/src/func.rs
+++ b/spirq-core/src/func.rs
@@ -26,13 +26,25 @@ pub struct Function {
 
 #[derive(Default)]
 pub struct FunctionRegistry {
+    called: HashSet<FunctionId>,
     func_map: HashMap<FunctionId, Function>,
 }
 impl FunctionRegistry {
-    pub fn set(&mut self, id: FunctionId, func: Function) -> Result<()> {
+    pub fn called(&mut self, id: FunctionId) {
+        if let Some(func) = self.func_map.get_mut(&id) {
+            func.callees.insert(id);
+        } else {
+            self.called.insert(id);
+        }
+    }
+
+    pub fn set(&mut self, id: FunctionId, mut func: Function) -> Result<()> {
         use std::collections::hash_map::Entry;
         match self.func_map.entry(id) {
             Entry::Vacant(entry) => {
+                if self.called.remove(&id) {
+                    func.callees.insert(id);
+                }
                 entry.insert(func);
                 Ok(())
             }

--- a/spirq/src/reflect.rs
+++ b/spirq/src/reflect.rs
@@ -617,9 +617,7 @@ impl Inspector for FunctionInspector {
             }
             Op::FunctionCall => {
                 let op = OpFunctionCall::try_from(instr)?;
-                let func_id = op.func_id;
-                let func = itm.func_reg.get_mut(func_id)?;
-                func.callees.insert(func_id);
+                itm.func_reg.called(op.func_id);
             }
             _ => {
                 if let Some((_func_id, func)) = self.cur_func.as_mut() {

--- a/spirq/src/reflect.rs
+++ b/spirq/src/reflect.rs
@@ -537,7 +537,12 @@ impl<'a> ReflectIntermediate<'a> {
                     .get_u32(op.const_id, spirv::Decoration::SpecId)?;
                 let ty = self.ty_reg.get(op.ty_id)?.clone();
                 let constant = if let Some(user_value) = self.cfg.spec_values.get(&spec_id) {
-                    Constant::new(name, ty, user_value.clone())
+                    let user_value = if matches!(user_value, ConstantValue::Typeless(_)) {
+                        user_value.to_typed(&ty)?
+                    } else {
+                        user_value.clone()
+                    };
+                    Constant::new(name, ty, user_value)
                 } else {
                     let value = match opcode {
                         Op::SpecConstantTrue => ConstantValue::from(true),


### PR DESCRIPTION
I found these two issues testing https://github.com/attackgoat/screen-13/pull/68, however I'm not sure they are done in the best way yet.

## Commit [`e8c5d00`](https://github.com/PENGUINLIONG/spirq-rs/tree/e8c5d0039575a3feb2493b446fdedfeb21a729ef)

Fixes a panic at `spirq/src/reflect.rs:621`.

Valid SPIR-V may list function body instructions after their first call. The function type declaration of course always happens before the first call. This can be reproduced with the following shader using `shader-reflect`:

```glsl
#version 460 core

vec4 a() {
    return vec4(0);
}

void main() {
    gl_Position = a();
}
```

## Commit [`7ee6d99`](https://github.com/PENGUINLIONG/spirq-rs/tree/7ee6d994477219671bcdc66eb8004354f4806597)

Specialization constants that are found via `ReflectConfig::specialize(..)` are `ConstantValue::Typeless(_)` and remain untyped after processing their spec-const instructions. The typeless state is helpful because Vulkan doesn't require that information from users and so it is very handy to let `spirq` reflect that info automatically.