### PR TITLE
Add support for explicitly typed constants

### DIFF
--- a/spirq-core/src/constant.rs
+++ b/spirq-core/src/constant.rs
@@ -135,9 +135,7 @@ impl ConstantValue {
                     let x = u64::from_ne_bytes([x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7]]);
                     Ok(ConstantValue::U64(x))
                 }
-                ScalarType::Float { bits: 16 } if x.len() == 4 => {
-                    Ok(ConstantValue::F16())
-                }
+                ScalarType::Float { bits: 16 } if x.len() == 4 => Ok(ConstantValue::F16()),
                 ScalarType::Float { bits: 32 } if x.len() == 4 => {
                     let x = f32::from_ne_bytes([x[0], x[1], x[2], x[3]]);
                     Ok(ConstantValue::F32(OrderedFloat(x)))


### PR DESCRIPTION
I found this testing https://github.com/attackgoat/screen-13/pull/68

<details>
  <summary>Example shader</summary>
  
  ```glsl
  #version 460 core
  #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
  #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
  #extension GL_EXT_shader_explicit_arithmetic_types_int32 : require
  #extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
  #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
  #extension GL_EXT_shader_explicit_arithmetic_types_float32 : require
  #extension GL_EXT_shader_explicit_arithmetic_types_float64 : require
  
  const int8_t INT8 = int8_t(1);
  const int16_t INT16 = int16_t(1);
  const int32_t INT32 = int32_t(1);
  const int64_t INT64 = int64_t(1);
  
  const uint8_t UINT8 = uint8_t(1);
  const uint16_t UINT16 = uint16_t(1);
  const uint32_t UINT32 = uint32_t(1);
  const uint64_t UINT64 = uint64_t(1);
  
  const float16_t FLOAT16 = float16_t(1.0);
  const float32_t FLOAT32 = float32_t(1.0);
  const float64_t FLOAT64 = float64_t(1.0);
  
  void main() {
  }
  ```
</details>

These constants probably don't need to be parsed, invalidating this change. If they should be parsed then maybe [`half`](https://docs.rs/half/latest/half/) could help with the `f16` representation.