### PR TITLE
Mark base variable as accessed for nested access chains

### DIFF
--- a/spirq/src/reflect.rs
+++ b/spirq/src/reflect.rs
@@ -646,16 +646,18 @@ impl Inspector for FunctionInspector {
                     } else if op == Op::Load || is_atomic_load_op(op) {
                         let op = OpLoad::try_from(instr)?;
                         let mut var_id = op.var_id;
-                        // Resolve access chain.
-                        if let Some(&x) = self.access_chain_map.get(&var_id) {
+                        // Resolve the access chain transitively until
+                        // reaching the base variable.
+                        while let Some(&x) = self.access_chain_map.get(&var_id) {
                             var_id = x
                         }
                         func.accessed_vars.insert(var_id);
                     } else if op == Op::Store || is_atomic_store_op(op) {
                         let op = OpStore::try_from(instr)?;
                         let mut var_id = op.var_id;
-                        // Resolve access chain.
-                        if let Some(&x) = self.access_chain_map.get(&var_id) {
+                        // Resolve the access chain transitively until
+                        // reaching the base variable.
+                        while let Some(&x) = self.access_chain_map.get(&var_id) {
                             var_id = x
                         }
                         func.accessed_vars.insert(var_id);


### PR DESCRIPTION
When inspecting a function's instructions, a load or store through a nested access chain (an access chain based on another access chain) marked an intermediate access-chain result as accessed, rather than the base variable. As a result, a variable reached only through such a chain was considered unused and dropped from the reflection output.

This happens, for example, with an SSBO whose element is a struct that is accessed member-wise (`buffer[i].member`), where the compiler emits one access chain to the element and a second into the member.

With this PR, the access chain is resolved transitively up to the base variable, which is then marked as accessed.